### PR TITLE
Fixed an error with is_read causing SOAP errors by only including it …

### DIFF
--- a/lib/ews/templates/message.rb
+++ b/lib/ews/templates/message.rb
@@ -64,7 +64,7 @@ module Viewpoint::EWS
         bcc_r = bcc_recipients.collect{|r| {mailbox: {email_address: r}}}
         msg[:bcc_recipients] = bcc_r unless bcc_r.empty?
 
-        msg[:is_read] = is_read
+        msg[:is_read] = is_read if is_read != nil
 
         msg[:extended_properties] = extended_properties unless extended_properties.empty?
 


### PR DESCRIPTION
…in the message xml if it is not null